### PR TITLE
Fix .gitattributes stripping package.json from installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,8 +22,3 @@ CLAUDE.md export-ignore
 CONTRIBUTING.md export-ignore
 phpunit.xml export-ignore
 README.md export-ignore
-
-# Exclude build and dependency files
-package.json export-ignore
-package-lock.json export-ignore
-vite.config.js export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-28
+
+### Fixed
+
+- `package.json`, `package-lock.json`, and `vite.config.js` are no longer marked `export-ignore` in `.gitattributes`. Previously these files were stripped from `composer create-project` / `laravel new` installs, breaking `npm run build` with `ENOENT: no such file or directory, open '.../package.json'`.
+
 ## [1.0.0] - 2026-04-28
 
 First stable release. The kit pivots the original `livewire-starter-kit` to a Laravel + Inertia.js + Vue stack using the ArtisanPack UI ecosystem.
@@ -37,6 +43,7 @@ First stable release. The kit pivots the original `livewire-starter-kit` to a La
 - `ThemeSetupCommand` — depended on `artisanpack:generate-theme` which lived in `livewire-ui-components`. Theming will be re-wired against `@artisanpack-ui/tokens` in a future release.
 - `tests/Feature/Console/InstallationTest.php` — referenced removed Livewire artifacts.
 
+[1.0.1]: https://github.com/ArtisanPack-UI/vue-starter-kit/releases/tag/v1.0.1
 [1.0.0]: https://github.com/ArtisanPack-UI/vue-starter-kit/releases/tag/v1.0.0
 
 ## [0.1.0-dev]

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "laravel",
         "framework"
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "require": {
         "php": "^8.2",


### PR DESCRIPTION
<!--- Fix .gitattributes stripping package.json from installs -->


## Description

Removes `export-ignore` directives for `package.json`, `package-lock.json`, and `vite.config.js` so they survive `git archive` / `composer create-project` exports. Fresh `laravel new` installs were unable to run `npm install` or `npm run build` because these files were stripped.

**Closes:** #13

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #13

## Motivation and Context

Without these files, `npm run build` fails with `ENOENT: no such file or directory, open '.../package.json'` immediately after `laravel new --using=ArtisanPack-UI/<repo>`. The Laravel installer's "Assets built" step fails and the project can't compile its frontend at all.

## Changes Made

- Removed `package.json export-ignore` from `.gitattributes`
- Removed `package-lock.json export-ignore` from `.gitattributes`
- Removed `vite.config.js export-ignore` from `.gitattributes`
- Bumped `composer.json` version to `1.0.1`
- Added `1.0.1` entry to `CHANGELOG.md`

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4 (Darwin)
- PHP Version: 8.4.3
- Project Version: 1.0.1

**Tests Performed:**
1. Verified the three `export-ignore` lines were the only changes needed by inspecting a broken `react-test/` install: `package-lock.json` was 89 bytes and `package.json`/`vite.config.js` were missing entirely.
2. Confirmed the rest of `.gitattributes` (text/eol normalization, dev-file ignores) is unchanged.
3. Local `git diff` reviewed — only `.gitattributes`, `CHANGELOG.md`, and `composer.json` changed.

End-to-end re-test of `laravel new ... --using=...release/1.0.1` will need to happen against the published tag once this is merged and `v1.0.1` is cut.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — change is to `.gitattributes` and metadata only; no UI surface affected.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** No tests added — `.gitattributes` behavior is verified at the `git archive` / `composer create-project` boundary, which is exercised by tagging and shipping. The bug is fully reproduced by the missing-files install footprint and the fix is the inverse.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** CHANGELOG entry covers it.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (N/A)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a packaging export issue where certain project files were being excluded from exports, which could cause build failures in downstream environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->